### PR TITLE
ファイル読み込み失敗時でも非ゼロステータスで終了する修正

### DIFF
--- a/cat.rs
+++ b/cat.rs
@@ -11,7 +11,10 @@ fn main() {
         stderr.write_str("file name not given\n");
     }
     for path in paths.iter() {
-        do_cat(path).ok().expect(path.as_slice());
+        let res = do_cat(path);
+        if res.is_err() {
+            panic!("{}: {}", path, res.unwrap_err());
+        }
     }
 }
 

--- a/cat.rs
+++ b/cat.rs
@@ -4,14 +4,13 @@ use std::io::{File, IoResult, IoError, EndOfFile};
 use std::io::stdio::{stdout_raw, stderr};
 
 fn main() {
-    let mut args = os::args();
-    args.remove(0);
+    let paths = os::args().slice_from_or_fail(&1).to_vec();
     let mut stderr = stderr();
 
-    if args.len() < 1 {
+    if paths.len() < 1 {
         stderr.write_str("file name not given\n");
     }
-    for path in args.iter() {
+    for path in paths.iter() {
         do_cat(path).ok().expect(path.as_slice());
     }
 }


### PR DESCRIPTION
権限不足でファイルの読み込みに失敗した時などに、プロセスを非ゼロステータスで終了するように修正した。
- 参考: [Rustのエラー処理のガイド - Qiita](http://qiita.com/kondei/items/c7175ed278bb4fbd4d16)

ついでに `mut` なるべくを使わないように修正:

> There are other good reasons to avoid mutable state when possible,
> http://doc.rust-lang.org/guide.html#variable-bindings

ということらしいので。
